### PR TITLE
feat(orm): RawQueryBuilderFactory와 ResultTransformerFactory 추가

### DIFF
--- a/__test__/e2e/orm/orm-entity.test.ts
+++ b/__test__/e2e/orm/orm-entity.test.ts
@@ -79,6 +79,9 @@ describe("커스텀 ORM 테스트", () => {
                 where: {
                     id: 1,
                 },
+                orderBy: {
+                    id: "ASC",
+                },
             });
 
             console.log("node", node);


### PR DESCRIPTION
Fixes #55

RawQueryBuilderFactory를 통하여 쿼리를 빌드할 수 있습니다.

```ts
const query = RawQueryBuilderFactory.create()
    .select(["u.id", "u.name", "p.title"])
    .from("users", "u")
    .join(
        "LEFT",
        "posts",
        "p",
        Conditions.equals("u.id", "p.user_id"),
    )
    .where([
        Conditions.and([
            Conditions.gte("u.created_at", new Date("2024-01-01")
            Conditions.or([
                Conditions.like("u.email", "%@example.com"),
                Conditions.like("u.email", "%@test.com"),
            ]),
        ]),
    ])
    .groupBy(["u.id", "u.name"])
    .having([Conditions.gt("COUNT(p.id)", 5)])
    .orderBy([{ column: "u.created_at", direction: "DESC" }])
    .limit([0, 10])
    .build();
expect(query.sql).toContain("SELECT u.id, u.name, p.title");
expect(query.sql).toContain("FROM users AS u");
expect(query.sql).toContain("LEFT JOIN posts AS p ON u.id = ?");
expect(query.sql).toContain("WHERE");
expect(query.sql).toContain("GROUP BY u.id, u.name");
expect(query.sql).toContain("HAVING COUNT(p.id) > ?");
expect(query.sql).toContain("ORDER BY u.created_at DESC");
expect(query.sql).toContain("LIMIT ?, ?");
```

RawQueryBuilder는 타입에 안전하지 않습니다. 

RawQueryBuilder를 래핑하여 타입에 안전한 쿼리 빌더 객체를 만들어야 할 것 같습니다.

```ts
const node = await nodeRepository.findOne({
    where: {
        id: 1,
    },
    orderBy: {
        id: "ASC",
    },
});
```

EntityManager를 사용한다면 내부적으로 QueryBuiler로 변환한 후 처리합니다.