### PR TITLE
Biud436/issue46

### DIFF
--- a/__test__/unit/result-transformer.test.ts
+++ b/__test__/unit/result-transformer.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import "reflect-metadata";
-import { Expose, Type } from "class-transformer";
+import { Expose } from "class-transformer";
 import { Column, Entity, ManyToOne } from "@stingerloom/core/orm/decorators";
 import { QueryResult } from "@stingerloom/core/orm/types";
 import { ResultTransformerFactory } from "@stingerloom/core/orm/core";
@@ -19,6 +19,9 @@ describe("ResultTransformer", () => {
         @Column()
         @Expose()
         created_at!: Date;
+
+        @Expose()
+        posts?: Post[];
     }
 
     @Entity()
@@ -36,9 +39,12 @@ describe("ResultTransformer", () => {
         content!: string;
 
         @Expose()
-        @Type(() => PostComment)
         @Column()
-        comments?: PostComment[];
+        @ManyToOne(() => PostComment, (entity) => entity.posts)
+        comment?: PostComment;
+
+        @Expose()
+        users?: User[];
     }
 
     @Entity()
@@ -57,8 +63,8 @@ describe("ResultTransformer", () => {
 
         @Column()
         @Expose()
-        @Type(() => Post)
-        posts?: Post[];
+        @ManyToOne(() => Post, (entity) => entity.users)
+        post?: Post;
     }
 
     const resultTransformer = ResultTransformerFactory.create();
@@ -165,12 +171,12 @@ describe("ResultTransformer", () => {
                         id: 1,
                         name: "홍길동",
                         email: "hong@example.com",
-                        posts_id: 1,
-                        posts_title: "첫 번째 글",
-                        posts_content: "내용입니다",
-                        posts_comments_id: 1,
-                        posts_comments_content: "댓글입니다",
-                        posts_comments_created_at: "2024-03-16T00:00:00Z",
+                        post_id: 1,
+                        post_title: "첫 번째 글",
+                        post_content: "내용입니다",
+                        post_comment_id: 1,
+                        post_comment_content: "댓글입니다",
+                        post_comment_created_at: "2024-03-16T00:00:00Z",
                     },
                 ],
             };
@@ -182,21 +188,19 @@ describe("ResultTransformer", () => {
             expect(result).toBeInstanceOf(User);
             const user = result as User;
 
-            // posts 배열 검증
-            expect(user.posts).toBeDefined();
-            expect(Array.isArray(user.posts)).toBeTruthy();
-            expect(user?.posts?.length).toBeGreaterThan(0);
+            console.log(user);
 
             // post 객체 검증
-            const post = user?.posts?.[0];
+            const post = user?.post;
+
             expect(post).toBeInstanceOf(Post);
             expect(post?.id).toBe(1);
             expect(post?.title).toBe("첫 번째 글");
             expect(post?.content).toBe("내용입니다");
 
             // comments 배열 검증 (중첩의 중첩인 경우에는 comments가 배열로 변환되어야 하는데 실패함)
-            expect(post?.comments).not.toBeDefined();
-            expect(Array.isArray(post?.comments)).toBeFalsy();
+            expect(post?.comment).toBeDefined();
+            expect(Array.isArray(post?.comment)).toBeFalsy();
         });
 
         it("중첩 관계가 없는 경우에도 정상 동작해야 합니다", () => {
@@ -221,7 +225,6 @@ describe("ResultTransformer", () => {
             expect(user.id).toBe(1);
             expect(user.name).toBe("홍길동");
             expect(user.email).toBe("hong@example.com");
-            expect(user.posts).toBeUndefined();
         });
 
         it("다중 레벨의 중첩 관계를 변환할 수 있어야 합니다", () => {
@@ -231,30 +234,28 @@ describe("ResultTransformer", () => {
                         id: 1,
                         name: "홍길동",
                         email: "hong@example.com",
-                        posts_id: 1,
-                        posts_title: "첫 번째 글",
-                        posts_content: "내용입니다",
-                        comments_id: 1,
-                        comments_content: "댓글입니다",
-                        comments_created_at: "2024-03-16T00:00:00Z",
+                        post_id: 1,
+                        post_title: "첫 번째 글",
+                        post_content: "내용입니다",
+                        comment_id: 1,
+                        comment_content: "댓글입니다",
+                        comment_created_at: "2024-03-16T00:00:00Z",
                     },
                 ],
             };
 
             const result = resultTransformer.transformNested(User, mockResult, {
-                posts: Post,
-                comments: PostComment,
+                post: Post,
+                comment: PostComment,
             });
-
-            console.log(result);
 
             expect(result).toBeInstanceOf(User);
             const user = result as User;
-            expect(user.posts).toBeDefined();
-            expect(user.posts?.[0]).toBeInstanceOf(Post);
-            if (user.posts?.[0].comments) {
-                expect(user.posts[0].comments[0]).toBeInstanceOf(PostComment);
-            }
+            expect(user.post).toBeDefined();
+            expect(user.post).toBeInstanceOf(Post);
+            // if (user.post?.comment) {
+            expect(user.post?.comment).toBeInstanceOf(PostComment);
+            // }
         });
 
         it("단일 행에 다수의 중첩된 관계 데이터 포함", () => {
@@ -263,6 +264,7 @@ describe("ResultTransformer", () => {
                     {
                         id: 1,
                         name: "Alice",
+                        email: "alice@stingerloom.com",
                         // 'address' 관계 데이터 (키 접두사 "address_" 사용)
                         address_street: "123 Main St",
                         address_city: "Anytown",
@@ -327,10 +329,8 @@ describe("ResultTransformer", () => {
                 },
             ) as GoodUser;
 
-            console.log(result);
-
             expect(result).toBeInstanceOf(GoodUser);
-            expect((result?.address as any)[0]).toBeInstanceOf(Address);
+            expect(result?.address).toBeInstanceOf(Address);
         });
     });
 });

--- a/__test__/unit/result-transformer.test.ts
+++ b/__test__/unit/result-transformer.test.ts
@@ -310,11 +310,11 @@ describe("ResultTransformer", () => {
                 email!: string;
 
                 @Expose()
-                @ManyToOne(() => Address, (entity) => entity.users)
+                @ManyToOne(() => Address, (entity) => entity.users, {})
                 address!: Address;
 
-                @Expose()
-                @ManyToOne(() => Order, (entity) => entity.users)
+                // @Expose()
+                @ManyToOne(() => Order, (entity) => entity.users, {})
                 order!: Order;
             }
 

--- a/packages/core/orm/core/ResultTransformer.ts
+++ b/packages/core/orm/core/ResultTransformer.ts
@@ -10,7 +10,7 @@ import {
 } from "../decorators";
 
 export class ResultTransformer implements BaseResultTransformer {
-    private static SEPERATOR = "_";
+    private static PropertySeperator = "_";
 
     /**
      * 쿼리 결과가 없는 경우를 확인합니다.
@@ -37,7 +37,9 @@ export class ResultTransformer implements BaseResultTransformer {
         const enties = Object.entries(row);
 
         for (const [key, value] of enties) {
-            const isUnderScored = key.includes(ResultTransformer.SEPERATOR);
+            const isUnderScored = key.includes(
+                ResultTransformer.PropertySeperator,
+            );
             if (!isUnderScored) {
                 baseEntity[key] = value;
             }
@@ -51,16 +53,20 @@ export class ResultTransformer implements BaseResultTransformer {
             console.log("baseCls:", baseCls);
             console.log("entityCls:", entityClass);
             console.log("propertyCls:", propertyCls);
-            console.log("key:", key.split(ResultTransformer.SEPERATOR)[1]);
+            console.log(
+                "key:",
+                key.split(ResultTransformer.PropertySeperator)[1],
+            );
 
             const isManyToOneColumn = propertyCls?.find(
                 (e) =>
-                    e.columnName === key.split(ResultTransformer.SEPERATOR)[1],
+                    e.columnName ===
+                    key.split(ResultTransformer.PropertySeperator)[1],
             );
 
             if (isManyToOneColumn) {
                 console.log(
-                    `${key.split(ResultTransformer.SEPERATOR)[1]}는 ManyToOne 컬럼입니다`,
+                    `${key.split(ResultTransformer.PropertySeperator)[1]}는 ManyToOne 컬럼입니다`,
                 );
             }
         }
@@ -173,7 +179,7 @@ export class ResultTransformer implements BaseResultTransformer {
 
                 // 현재 관계에 해당하는 데이터 추출
                 const relationData = {} as any;
-                const propertyName = `${entityKey}${ResultTransformer.SEPERATOR}`;
+                const propertyName = `${entityKey}${ResultTransformer.PropertySeperator}`;
                 Object.entries(row)
                     .filter(([key]) => key.startsWith(propertyName))
                     .forEach(([key, value]) => {

--- a/packages/core/orm/core/ResultTransformer.ts
+++ b/packages/core/orm/core/ResultTransformer.ts
@@ -190,7 +190,9 @@ export class ResultTransformer implements BaseResultTransformer {
                         relationData[formattedPropertyName] = value;
                     });
 
-                const hasRelationData = Object.keys(relationData).length > 0;
+                const relationKeys = Object.keys(relationData);
+
+                const hasRelationData = relationKeys.length > 0;
                 if (hasRelationData) {
                     if (!nestedEntities[entityKey]) {
                         nestedEntities[entityKey] = [];

--- a/packages/core/orm/decorators/ManyToOne.ts
+++ b/packages/core/orm/decorators/ManyToOne.ts
@@ -51,7 +51,7 @@ export type ManyToOneMetadata<T> = {
  */
 export function ManyToOne<T extends EntityLike>(
     getMappingEntity: RetrieveEntity<T>,
-    getMappingProperty: SetRelatedEntity<EntityLike>,
+    getMappingProperty: SetRelatedEntity<T>,
     option?: ManyToOneOption,
 ): PropertyDecorator {
     return (target, propertyKey) => {

--- a/packages/core/orm/decorators/ManyToOne.ts
+++ b/packages/core/orm/decorators/ManyToOne.ts
@@ -72,8 +72,6 @@ export function ManyToOne<T extends EntityLike>(
             option,
         };
 
-        console.log("ManyToOne's target", target.constructor.name);
-
         const columns = Reflect.getMetadata(MANY_TO_ONE_TOKEN, target);
 
         Reflect.defineMetadata(

--- a/packages/core/orm/decorators/ManyToOne.ts
+++ b/packages/core/orm/decorators/ManyToOne.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { ClazzType, ReflectManager } from "@stingerloom/core/common";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -54,16 +55,15 @@ export function ManyToOne<T extends EntityLike>(
     option?: ManyToOneOption,
 ): PropertyDecorator {
     return (target, propertyKey) => {
-        const mappedEntity = getMappingEntity();
+        // const mappedEntity = getMappingEntity();
 
-        const injectParam = ReflectManager.getType<any>(
-            mappedEntity.prototype,
-            propertyKey,
-        );
+        const cls = target.constructor;
+
+        const injectParam = ReflectManager.getType<any>(cls, propertyKey);
 
         const columnName = propertyKey.toString();
         const metadata = <ManyToOneMetadata<T>>{
-            target,
+            target: cls,
             type: injectParam,
             columnName, // 조인 컬럼이 필요... 이건 productId가 되어야 하는데, product가 되어버림...
             joinColumn: option?.joinColumn,
@@ -72,12 +72,16 @@ export function ManyToOne<T extends EntityLike>(
             option,
         };
 
-        const columns = Reflect.getMetadata(MANY_TO_ONE_TOKEN, target);
+        // console.log("target:", target.constructor);
+        // console.log("entityTarget:", entityTarget);
+        // console.log("propertyTarget", mappedEntity);
+
+        const columns = Reflect.getMetadata(MANY_TO_ONE_TOKEN, cls);
 
         Reflect.defineMetadata(
             MANY_TO_ONE_TOKEN,
             [...(columns || []), metadata],
-            target,
+            cls,
         );
 
         // 스캐너가 따로 있어야 할까?


### PR DESCRIPTION

`fillPropertiesToForeignObject`를 `ResultTransformer`에 추가

기본 로직은 다음과 같습니다.

1. 코어 엔티티에서 기본적인 속성을 추출한다.
2. 엔티티에 필요한 외래키 오브젝트를 만든다.
3. 외래키 오브젝트에 키/값을 채워넣는다.
4. 코어 엔티티에 외래키 오브젝트를 추가한다.
5. 외래키가 없을 때까지 2-4를 재귀적으로 반복한다.

Fixes #46