### PR TITLE
fix: Fix router path normalization

### DIFF
--- a/packages/core/error/index.ts
+++ b/packages/core/error/index.ts
@@ -2,7 +2,6 @@ export * from "./Exception";
 export * from "./InternalServerException";
 export * from "./BadRequestException";
 export * from "./UnauthorizedException";
-export * from "./BadRequestException";
 export * from "./DatabaseConnectionFailedError";
 export * from "./DatabaseNotConnectedError";
 export * from "./NotSupportedDatabaseTypeError";

--- a/packages/core/orm/core/ResultTransformer.ts
+++ b/packages/core/orm/core/ResultTransformer.ts
@@ -14,7 +14,7 @@ import { ClazzType } from "@stingerloom/core/common";
 export type ForeignObject<T = any> = { [key: string]: T };
 
 export class ResultTransformer implements BaseResultTransformer {
-  private static PropertySeperator = "_";
+  private static PropertySeparator = "_";
 
   /**
    * 쿼리 결과가 없는 경우를 확인합니다.
@@ -41,7 +41,7 @@ export class ResultTransformer implements BaseResultTransformer {
     const enties = Object.entries(row);
 
     for (const [key, value] of enties) {
-      const isUnderScored = key.includes(ResultTransformer.PropertySeperator);
+      const isUnderScored = key.includes(ResultTransformer.PropertySeparator);
       if (!isUnderScored) {
         baseEntity[key] = value;
       }
@@ -72,8 +72,8 @@ export class ResultTransformer implements BaseResultTransformer {
   /**
    * SQL 측 컬럼명을 만듭니다.
    */
-  private makeColumnNameWithSeperator(columnName: string): string {
-    return `${columnName}${ResultTransformer.PropertySeperator}`;
+  private makeColumnNameWithSeparator(columnName: string): string {
+    return `${columnName}${ResultTransformer.PropertySeparator}`;
   }
 
   /**
@@ -168,7 +168,7 @@ export class ResultTransformer implements BaseResultTransformer {
 
         // ! 3. 외래키 오브젝트에 키/값을 채워넣는다.
         for (const [key, value] of rows) {
-          const prefix = this.makeColumnNameWithSeperator(columnName);
+          const prefix = this.makeColumnNameWithSeparator(columnName);
 
           if (key.startsWith(prefix)) {
             const keyWithoutPrefix = key.replace(prefix, "");

--- a/packages/core/router/RouterExecutionContext.ts
+++ b/packages/core/router/RouterExecutionContext.ts
@@ -105,7 +105,10 @@ export class RouterExecutionContext {
   }
 
   private normalizePath(controllerPath: string, routePath: string): string {
-    return path.posix.join(controllerPath, routePath);
+    const base = controllerPath.replace(/\/$/, "");
+    const route = routePath.replace(/^\//, "");
+    const joined = path.posix.join(base, route);
+    return joined.startsWith("/") ? joined : `/${joined}`;
   }
 
   private transformResponse(result: any): any {


### PR DESCRIPTION
## Summary
- normalize routing paths correctly so leading slashes on routes don't override controller paths
- remove duplicate export from error index
- correct typo `PropertySeparator` in ResultTransformer

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_683fc7bb2e0c832ea23686fa5eec48ea