### PR TITLE
fix: Fix setHeader handling in Express adapter

### DIFF
--- a/packages/core/common/http/adapters/express/ExpressResponseAdapter.ts
+++ b/packages/core/common/http/adapters/express/ExpressResponseAdapter.ts
@@ -31,7 +31,8 @@ export class ExpressResponseAdapter implements HttpResponse {
   }
 
   setHeader(name: string, value: string | number | string[]): this {
-    this.chaining(this.expressResponse.setHeader(name, value));
+    // express의 setHeader는 void를 반환하므로 체이닝을 사용하지 않습니다.
+    this.expressResponse.setHeader(name, value);
     return this;
   }
 


### PR DESCRIPTION
## Summary
- return `this` after `setHeader` instead of chaining the void return value

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'class-validator', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683fc8435d64832e8f07f68c9fd57f5f